### PR TITLE
elba.toml

### DIFF
--- a/elba.toml
+++ b/elba.toml
@@ -1,0 +1,14 @@
+[package]
+name = "idris-hackers/free"
+version = "0.1.0"
+authors = ["raichoo"]
+description = "Free monads for Idris"
+license = "BSD3"
+
+[targets.lib]
+path = "."
+mods = [ "Control.Monad.Free"
+       , "Control.Monad.Codensity"
+       , "Data.Functor.Coyoneda"
+       ]
+idris_opts = ["--warnreach"]


### PR DESCRIPTION
Add `elba.toml` for use with [elba](https://github.com/elba/elba) package manager.